### PR TITLE
Only depend on libuuid on Linux

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -13,12 +13,16 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
+ffmpeg:
+- '4.3'
 glib:
 - '2.58'
 libuuid:
 - 2.32.1
 pin_run_as_build:
+  ffmpeg:
+    max_pin: x.x
   libuuid:
     max_pin: x
 target_platform:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '10'
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -11,16 +11,16 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '10'
+- '11'
+ffmpeg:
+- '4.3'
 glib:
 - '2.58'
-libuuid:
-- 2.32.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:
-  libuuid:
-    max_pin: x
+  ffmpeg:
+    max_pin: x.x
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -2,8 +2,13 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+ffmpeg:
+- '4.3'
 glib:
 - '2.58'
+pin_run_as_build:
+  ffmpeg:
+    max_pin: x.x
 target_platform:
 - win-64
 vc:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About libignition-common3
 =========================
 
-Home: https://bitbucket.org/ignitionrobotics/ign-common
+Home: https://github.com/ignitionrobotics/ign-common
 
 Package license: Apache-2.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,7 +55,7 @@ test:
     - if exist %PREFIX%\\Library\\include\\ignition\common{{ major_version }}\ignition\common.hh (exit 0) else (exit 1)  # [win]
 
 about:
-  home: https://bitbucket.org/ignitionrobotics/ign-common
+  home: https://github.com/ignitionrobotics/ign-common
   license: Apache-2.0
   license_file: LICENSE
   summary: Ignition Common is a component in the ignition framework, a set of libraries designed to rapidly develop robot applications.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - libignition-math6
     - libignition-cmake2
     - dlfcn-win32  # [win]
-    - libuuid      # [not win]
+    - libuuid      # [linux]
     - freeimage
     - gts
     - tinyxml2
@@ -43,7 +43,7 @@ requirements:
   run:
     - libignition-math6
     - dlfcn-win32  # [win]
-    - libuuid      # [not win]
+    - libuuid      # [linux]
     - freeimage
     - gts
     - tinyxml2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,6 @@ requirements:
     - glib
     - ffmpeg
   run:
-    - libignition-math6
     - dlfcn-win32  # [win]
     - libuuid      # [linux]
     - freeimage

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,6 @@ requirements:
     - {{ compiler('cxx') }}  # [not win]
     - {{ compiler('c') }}    # [not win]
     - vs2017_win-64          # [win64]
-    - vs2017_win-32          # [win32]
     - cmake
     - ninja
     - pkgconfig
@@ -46,7 +45,6 @@ requirements:
     - libuuid      # [linux]
     - freeimage
     - gts
-    - tinyxml2
     - ffmpeg
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
       - framework.patch  # [osx]
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}


### PR DESCRIPTION
As on macOS the libuuid dependency can create conflicts, see https://github.com/conda-forge/libignition-cmake0-feedstock/pull/7 and https://github.com/conda-forge/libuuid-feedstock/issues/16 .

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
