### PR TITLE
Do not use vendored tinyxml2

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '9'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '9'
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 ffmpeg:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,7 +1,11 @@
+c_compiler:
+- vs2017
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- vs2017
 ffmpeg:
 - '4.3'
 glib:
@@ -11,5 +15,3 @@ pin_run_as_build:
     max_pin: x.x
 target_platform:
 - win-64
-vc:
-- '14'

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -11,6 +11,7 @@ cmake ^
     -DCMAKE_BUILD_TYPE=Release ^
     -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True ^
     -DCMAKE_CXX_STANDARD=17 ^
+    -DUSE_EXTERNAL_TINYXML2=ON ^
     %SRC_DIR%
 if errorlevel 1 exit 1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,18 +14,17 @@ source:
       - fix_test_break.patch
       - librt_linkage.patch  # [linux]
       - framework.patch  # [osx]
+      - use_external_tinyxml2.patch  # [win]
 
 build:
-  number: 3
-  skip: true  # [win and vc<14]
+  number: 4
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 
 requirements:
   build:
-    - {{ compiler('cxx') }}  # [not win]
-    - {{ compiler('c') }}    # [not win]
-    - vs2017_win-64          # [win64]
+    - {{ compiler('cxx') }}
+    - {{ compiler('c') }}
     - cmake
     - ninja
     - pkgconfig

--- a/recipe/use_external_tinyxml2.patch
+++ b/recipe/use_external_tinyxml2.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 00d8331..bd7b206 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -33,9 +33,8 @@ endif()
+ if(UNIX OR APPLE)
+   option(USE_EXTERNAL_TINYXML2 "Use a system-installed version of tinyxml2" ON)
+ elseif(WIN32)
+-  # This is always false for Windows, so we can avoid trying to search for a
+-  # system installation of tinyxml2.
+-  set(USE_EXTERNAL_TINYXML2 false)
++  # For backward compatibility, this option on Windows by default is OFF
++  option(USE_EXTERNAL_TINYXML2 "Use a system-installed version of tinyxml2" OFF)
+ endif()
+ 


### PR DESCRIPTION
Fix https://github.com/conda-forge/libignition-common-feedstock/issues/5 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

