### PR TITLE
Support paths from macros extended to support binary relocation

### DIFF
--- a/recipe/macro_path_binary_relocation.patch
+++ b/recipe/macro_path_binary_relocation.patch
@@ -1,0 +1,22 @@
+From 8d90eee1109a79135b5858d0d7a5fcb0f6cab641 Mon Sep 17 00:00:00 2001
+From: Diego <diego.ferigo@iit.it>
+Date: Tue, 6 Jul 2021 15:47:04 +0200
+Subject: [PATCH] Fix path in conda due to its binary relocation hacks
+
+---
+ src/SystemPaths.cc | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/SystemPaths.cc b/src/SystemPaths.cc
+index f809686..16e6e66 100644
+--- a/src/SystemPaths.cc
++++ b/src/SystemPaths.cc
+@@ -235,6 +235,8 @@ void SystemPaths::AddFilePaths(const std::string &_path)
+ std::string SystemPaths::NormalizeDirectoryPath(const std::string &_path)
+ {
+   std::string path = _path;
++  path.erase(std::find(path.begin(), path.end(), '\0'), path.end());
++
+   // Use '/' because it works on Linux, OSX, and Windows
+   std::replace(path.begin(), path.end(), '\\', '/');
+   // Make last character '/'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,8 +24,6 @@ requirements:
   build:
     - {{ compiler('cxx') }}
     - {{ compiler('c') }}
-    - git
-    - patch  # [not win]
     - cmake
     - ninja
     - pkgconfig

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
       - macro_path_binary_relocation  # [linux]
 
 build:
-  number: 2
+  number: 3
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
     patches:
       - librt_linkage.patch  # [linux]
       - framework.patch  # [osx]
+      - macro_path_binary_relocation  # [linux]
 
 build:
   number: 2
@@ -23,6 +24,8 @@ requirements:
   build:
     - {{ compiler('cxx') }}
     - {{ compiler('c') }}
+    - git
+    - patch
     - cmake
     - ninja
     - pkgconfig

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ compiler('c') }}
     - git
-    - patch
+    - patch  # [not win]
     - cmake
     - ninja
     - pkgconfig

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     patches:
       - librt_linkage.patch  # [linux]
       - framework.patch  # [osx]
-      - macro_path_binary_relocation  # [linux]
+      - macro_path_binary_relocation.patch  # [linux]
 
 build:
   number: 3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     patches:
       - librt_linkage.patch  # [linux]
       - framework.patch  # [osx]
-      - macro_path_binary_relocation.patch  # [linux]
+      - macro_path_binary_relocation.patch
 
 build:
   number: 3


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This PR should fix https://github.com/conda-forge/libignition-gazebo-feedstock/issues/4 by applying the patch proposed in https://github.com/conda-forge/libignition-gazebo-feedstock/issues/4#issuecomment-824709977. I only tested this patch in Ubuntu 20.04, therefore for the moment I restricted the application to this OS. In any case, other OSs are disabled in the gazebo recipe (https://github.com/conda-forge/libignition-gazebo-feedstock/issues/2).

This is my first attempt to packaging in conda, please let me know if anything is missing.
