### PR TITLE
Fix check for libraries being compiled and for autotick version update

### DIFF
--- a/.ci_support/migrations/tinyxml2-9.yaml
+++ b/.ci_support/migrations/tinyxml2-9.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-tinyxml2:
-- 9
-migrator_ts: 1624484606

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,7 @@ test:
     - test -f ${PREFIX}/lib/libignition-common{{ major_version }}-av.so  # [linux]
     - test -f ${PREFIX}/lib/libignition-common{{ major_version }}-graphics.dylib  # [osx]
     - test -f ${PREFIX}/lib/libignition-common{{ major_version }}-av.dylib  # [osx]
-    - test -f ${PREFIX}/lib/cmake/ignition-msgs{{ major_version }}/ignition-msgs{{ major_version }}-config.cmake  # [not win]
+    - test -f ${PREFIX}/lib/cmake/ignition-common{{ major_version }}/ignition-common{{ major_version }}-config.cmake  # [not win]
     - if exist %PREFIX%\\Library\\include\\ignition\common{{ major_version }}\ignition\common.hh (exit 0) else (exit 1)  # [win]
     - if exist $PREFIX$\\Library\\lib\\ignition-common{{ major_version }}-graphics.lib (exit 0) else (exit 1)  # [win]
     - if exist $PREFIX$\\Library\\lib\\ignition-common{{ major_version }}-av.lib (exit 0) else (exit 1)  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
       - macro_path_binary_relocation.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,15 @@
 {% set base_name = "libignition-common" %}
-{% set version = "4.1.0" %}
-{% set major_version = version.split('.')[0] %}
+{% set version = "4_4.1.0" %}
+{% set version_clean = version.split('_')[1] %}
+{% set major_version = version.split('_')[0] %}
 {% set name = base_name + major_version %}
 
 package:
   name: {{ name }}
-  version: {{ version }}
+  version: {{ version_clean }}
 
 source:
-  - url: https://github.com/ignitionrobotics/ign-common/archive/ignition-common{{ major_version }}_{{ version }}.tar.gz
+  - url: https://github.com/ignitionrobotics/ign-common/archive/ignition-common{{ version }}.tar.gz
     sha256: b6d223fb30a053385b4b86f45db2684d28acde280d64272eb84437431513d5b5
     patches:
       - librt_linkage.patch  # [linux]
@@ -48,7 +49,18 @@ requirements:
 test:
   commands:
     - test -f ${PREFIX}/include/ignition/common{{ major_version }}/ignition/common.hh  # [not win]
+    - test -f ${PREFIX}/lib/libignition-common{{ major_version }}-graphics.so  # [linux]
+    - test -f ${PREFIX}/lib/libignition-common{{ major_version }}-av.so  # [linux]
+    - test -f ${PREFIX}/lib/libignition-common{{ major_version }}-graphics.dylib  # [osx]
+    - test -f ${PREFIX}/lib/libignition-common{{ major_version }}-av.dylib  # [osx]
+    - test -f ${PREFIX}/lib/cmake/ignition-msgs{{ major_version }}/ignition-msgs{{ major_version }}-config.cmake  # [not win]
     - if exist %PREFIX%\\Library\\include\\ignition\common{{ major_version }}\ignition\common.hh (exit 0) else (exit 1)  # [win]
+    - if exist $PREFIX$\\Library\\lib\\ignition-common{{ major_version }}-graphics.lib (exit 0) else (exit 1)  # [win]
+    - if exist $PREFIX$\\Library\\lib\\ignition-common{{ major_version }}-av.lib (exit 0) else (exit 1)  # [win]
+    - if exist $PREFIX$\\Library\\bin\\ignition-common{{ major_version }}-graphics.dll (exit 0) else (exit 1)  # [win]
+    - if exist $PREFIX$\\Library\\bin\\ignition-common{{ major_version }}-av.dll (exit 0) else (exit 1)  # [win]
+    - if exist %PREFIX%\\Library\\lib\\cmake\\ignition-common{{ major_version }}\\ignition-common{{ major_version }}-config.cmake (exit 0) else (exit 1)  # [win]
+
 
 about:
   home: https://github.com/ignitionrobotics/ign-common


### PR DESCRIPTION
This PR checks that the part of ignition-common with optional dependencies are actually built (fix https://github.com/conda-forge/libignition-common-feedstock/issues/17). 

Furthermore, it changes the definition of the `version` variable to match the format used in the tags, i.e. `4_4.1.0`, so that the autotick-bot (that extracts the version information from git tags by stripping all the characters till the first digit) works fine. The version in `4.1.0` format is now contained in the `version_clean` variable (see https://github.com/conda-forge/libignition-msgs1-feedstock/issues/50).

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
