### PR TITLE
[v3] Add missing include cstdint for compilation in GCC 15

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '14'
+- '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 ffmpeg:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '14'
+- '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 ffmpeg:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '14'
+- '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 ffmpeg:

--- a/.ci_support/migrations/ffmpeg9.yaml
+++ b/.ci_support/migrations/ffmpeg9.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for ffmpeg 9
-  kind: version
-  migration_number: 1
-ffmpeg:
-- '9'
-migrator_ts: 1786327004.7804887

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '19'
+- '21'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '19'
+- '21'
 ffmpeg:
 - '9'
 glib:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '19'
+- '21'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '19'
+- '21'
 ffmpeg:
 - '9'
 glib:

--- a/recipe/add_missing_cstdint.patch
+++ b/recipe/add_missing_cstdint.patch
@@ -1,0 +1,21 @@
+From 83357ceef71ca530606da005f82666d4835ea199 Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio@traversaro.it>
+Date: Mon, 17 Aug 2026 00:11:12 +0200
+Subject: [PATCH] Add include for cstdint in Profiler.hh
+
+---
+ profiler/include/gz/common/Profiler.hh | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/profiler/include/gz/common/Profiler.hh b/profiler/include/gz/common/Profiler.hh
+index ef218f83f..d47b1f463 100644
+--- a/profiler/include/gz/common/Profiler.hh
++++ b/profiler/include/gz/common/Profiler.hh
+@@ -18,6 +18,7 @@
+ #ifndef GZ_COMMON_PROFILER_HH_
+ #define GZ_COMMON_PROFILER_HH_
+ 
++#include <cstdint>
+ #include <memory>
+ #include <string>
+ 

--- a/recipe/add_missing_cstdint.patch
+++ b/recipe/add_missing_cstdint.patch
@@ -1,12 +1,3 @@
-From 83357ceef71ca530606da005f82666d4835ea199 Mon Sep 17 00:00:00 2001
-From: Silvio Traversaro <silvio@traversaro.it>
-Date: Mon, 17 Aug 2026 00:11:12 +0200
-Subject: [PATCH] Add include for cstdint in Profiler.hh
-
----
- profiler/include/gz/common/Profiler.hh | 1 +
- 1 file changed, 1 insertion(+)
-
 diff --git a/profiler/include/gz/common/Profiler.hh b/profiler/include/gz/common/Profiler.hh
 index ef218f83f..d47b1f463 100644
 --- a/profiler/include/gz/common/Profiler.hh
@@ -19,3 +10,15 @@ index ef218f83f..d47b1f463 100644
  #include <memory>
  #include <string>
  
+diff --git a/include/gz/common/Battery.hh b/include/gz/common/Battery.hh
+index 05786e9e1..7e048628e 100644
+--- a/include/gz/common/Battery.hh
++++ b/include/gz/common/Battery.hh
+@@ -17,6 +17,7 @@
+ #ifndef GZ_COMMON_BATTERY_HH_
+ #define GZ_COMMON_BATTERY_HH_
+ 
++#include <cstdint>
+ #include <map>
+ #include <string>
+ #include <functional>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,10 +15,11 @@ source:
       - framework.patch  # [osx]
       - fix_test_break.patch
       - disable_rmt_apple_test.patch
+      - add_missing_cstdint.patch
 
 
 build:
-  number: 2
+  number: 3
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
